### PR TITLE
Specimen redesign

### DIFF
--- a/src/app/species-provider.tsx
+++ b/src/app/species-provider.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from "react";
+
+export interface SpeciesDetails {
+  name: string;
+}
+
+interface SpeciesContextValue {
+  details: SpeciesDetails;
+}
+
+const SpeciesContext = React.createContext<SpeciesContextValue | undefined>(undefined);
+
+export function SpeciesProvider({ name, children }: { name: string; children?: ReactNode }) {
+  const context = {
+    details: {
+      name,
+    },
+  };
+
+  return <SpeciesContext.Provider value={context}>{children}</SpeciesContext.Provider>;
+}
+
+export const useSpecies = () => React.useContext(SpeciesContext);

--- a/src/app/species/[name]/layout.tsx
+++ b/src/app/species/[name]/layout.tsx
@@ -1,9 +1,10 @@
-"use client";;
+"use client";
 import { use } from "react";
 
 import classes from "./layout.module.css";
 
 import { Container, Paper, Stack, Tabs } from "@mantine/core";
+import { SpeciesProvider } from "@/app/species-provider";
 import SpeciesHeader from "@/components/species-header";
 import { RedirectType, redirect, usePathname } from "next/navigation";
 import { useRouter } from "next/navigation";
@@ -11,13 +12,7 @@ import { MAX_WIDTH } from "@/app/constants";
 import { PreviousPage } from "@/components/navigation-history";
 import { PageCitation } from "@/components/page-citation";
 
-function DataTabs({
-  name,
-  children,
-}: {
-  name: string;
-  children: React.ReactNode;
-}) {
+function DataTabs({ name, children }: { name: string; children: React.ReactNode }) {
   const path = usePathname();
   const router = useRouter();
 
@@ -78,23 +73,23 @@ interface SpeciesLayoutProps {
 export default function SpeciesLayout(props: SpeciesLayoutProps) {
   const params = use(props.params);
 
-  const {
-    children
-  } = props;
+  const { children } = props;
 
   const name = decodeURIComponent(params.name);
   const canonicalName = name.replaceAll("_", " ");
 
   return (
-    <Stack gap={0} mt="xl">
-      <Container mb={20} w="100%" maw={MAX_WIDTH}>
-        <PreviousPage />
-      </Container>
-      <SpeciesHeader canonicalName={canonicalName} />
-      <DataTabs name={name}>
-        <Container maw={MAX_WIDTH}>{children}</Container>
-      </DataTabs>
-      <PageCitation />
-    </Stack>
+    <SpeciesProvider name={canonicalName}>
+      <Stack gap={0} mt="xl">
+        <Container mb={20} w="100%" maw={MAX_WIDTH}>
+          <PreviousPage />
+        </Container>
+        <SpeciesHeader canonicalName={canonicalName} />
+        <DataTabs name={name}>
+          <Container maw={MAX_WIDTH}>{children}</Container>
+        </DataTabs>
+        <PageCitation />
+      </Stack>
+    </SpeciesProvider>
   );
 }

--- a/src/app/species/[name]/page.tsx
+++ b/src/app/species/[name]/page.tsx
@@ -1,7 +1,5 @@
-'use client';
+"use client";
 
 export default function SpeciesPage() {
-  return (
-    <></>
-  );
+  return <></>;
 }

--- a/src/app/species/[name]/specimens/page.module.css
+++ b/src/app/species/[name]/specimens/page.module.css
@@ -1,0 +1,23 @@
+.skeletonOverview:where([data-visible])::before {
+    background-color: var(--mantine-color-wheat-2);
+}
+
+.skeletonOverview:where([data-visible])::after {
+    background-color: var(--mantine-color-wheat-1);
+}
+
+.cardTable {
+    th {
+        font-weight: 300;
+        background-color: transparent;
+        color: var(--mantine-color-midnight-9);
+        width: 1px;
+        white-space: nowrap;
+    }
+
+    td {
+        font-weight: 600;
+        color: var(--mantine-color-midnight-9);
+        width: 100%;
+    }
+}

--- a/src/app/species/[name]/specimens/page.tsx
+++ b/src/app/species/[name]/specimens/page.tsx
@@ -1,5 +1,417 @@
-import Specimens from "@/views/species/specimens/page";
+"use client";
 
-export default function Page(props: { params: Promise<{ name: string }> }) {
-  return <Specimens {...props} />;
+import classes from "./page.module.css";
+
+import { gql, useQuery } from "@apollo/client";
+import { AnalysisMap } from "@/components/mapping";
+import { AttributePillContainer } from "@/components/data-fields";
+import SimpleBarGraph from "@/components/graphing/SimpleBarGraph";
+import { AccessionEvent, CollectionEvent, SpecimenMapMarker, SpecimenOverview, YearValue } from "@/queries/specimen";
+import { Grid, Paper, Stack, Text, Title, Skeleton, Box, Table, Group, Image, Tooltip, Button } from "@mantine/core";
+import { ParentSize } from "@visx/responsive";
+import { scaleBand, scaleLinear } from "@visx/scale";
+import { max, min } from "d3";
+import { useSpecies } from "@/app/species-provider";
+
+const GET_SPECIMENS_OVERVIEW = gql`
+  query SpeciesSpecimens($canonicalName: String) {
+    species(canonicalName: $canonicalName) {
+      overview {
+        specimens {
+          ...SpecimenOverviewDetails
+        }
+      }
+    }
+  }
+`;
+
+interface OverviewQuery {
+  species: {
+    overview: {
+      specimens: SpecimenOverview;
+    };
+  };
+}
+
+const GET_SPECIMEN_MAP_MARKERS = gql`
+  query SpeciesSpecimenMapMarkers($canonicalName: String) {
+    species(canonicalName: $canonicalName) {
+      mapping {
+        specimens {
+          ...SpecimenMapMarkerDetails
+        }
+      }
+    }
+  }
+`;
+
+interface MappingQuery {
+  species: {
+    mapping: {
+      specimens: SpecimenMapMarker[];
+    };
+  };
+}
+
+const GET_SPECIMEN_CARD = gql`
+  query SpecimenCard($recordId: String) {
+    specimen(by: { recordId: $recordId }) {
+      collections {
+        ...CollectionEventDetails
+      }
+      accessions {
+        ...AccessionEventDetails
+      }
+    }
+  }
+`;
+
+interface SpecimenCardQuery {
+  specimen: {
+    collections: CollectionEvent[];
+    accessions: AccessionEvent[];
+  };
+}
+
+interface OverviewBlockProps {
+  title: string;
+  children?: React.ReactNode;
+  loading: boolean;
+}
+
+function OverviewBlock({ title, children, loading }: OverviewBlockProps) {
+  return (
+    <Skeleton visible={loading} radius="md" className={classes.skeletonOverview}>
+      <Paper radius="lg" p={20} bg="wheatBg.0" withBorder style={{ borderColor: "var(--mantine-color-wheatBg-1)" }}>
+        <Stack>
+          <Text fw={700} c="midnight" fz="xs">
+            {title}
+          </Text>
+          {children}
+        </Stack>
+      </Paper>
+    </Skeleton>
+  );
+}
+
+function Overview({ name }: { name: string }) {
+  const { loading, error, data } = useQuery<OverviewQuery>(GET_SPECIMENS_OVERVIEW, {
+    variables: { canonicalName: name },
+  });
+
+  return (
+    <Paper radius="lg" p={20} bg="wheatBg.0">
+      <Title order={3} c="wheat">
+        Specimens overview
+      </Title>
+
+      {error?.message}
+
+      <Grid columns={7}>
+        <Grid.Col span={5}>
+          <Skeleton visible={loading} radius="md" className={classes.skeletonOverview}>
+            <Paper
+              radius="lg"
+              p={20}
+              bg="wheatBg.0"
+              withBorder
+              style={{ borderColor: "var(--mantine-color-wheatBg-1)" }}
+            >
+              <Grid>
+                <Grid.Col span={2}>
+                  <Text fw={700} c="midnight" fz="xs">
+                    Total number of specimens
+                  </Text>
+                  <AttributePillContainer color="white">
+                    {data?.species.overview.specimens.total}
+                  </AttributePillContainer>
+                </Grid.Col>
+                <Grid.Col span={8} px={50}>
+                  <Text fw={700} c="midnight" fz="xs">
+                    Collection years
+                  </Text>
+                  <Box h={100}>
+                    {data && <CollectionYearsGraph data={data.species.overview.specimens.collectionYears} />}
+                  </Box>
+                </Grid.Col>
+                <Grid.Col span={2}>
+                  <Text fw={700} c="midnight" fz="xs">
+                    Top 5 bioregions
+                  </Text>
+                </Grid.Col>
+              </Grid>
+            </Paper>
+          </Skeleton>
+        </Grid.Col>
+        <Grid.Col span={2}>
+          <OverviewBlock title="Major collections" loading={loading}>
+            <Grid>
+              {data?.species.overview.specimens.majorCollections.map((collection) => (
+                <Grid.Col span={6} key={collection}>
+                  <AttributePillContainer color="white">{collection}</AttributePillContainer>
+                </Grid.Col>
+              ))}
+            </Grid>
+          </OverviewBlock>
+        </Grid.Col>
+
+        <Grid.Col span={1}>
+          <OverviewBlock title="Holotype" loading={loading}>
+            <AttributePillContainer color="white">{data?.species.overview.specimens.holotype}</AttributePillContainer>
+          </OverviewBlock>
+        </Grid.Col>
+        <Grid.Col span={1}>
+          <OverviewBlock title="Other types" loading={loading}>
+            <AttributePillContainer color="white">{data?.species.overview.specimens.otherTypes}</AttributePillContainer>
+          </OverviewBlock>
+        </Grid.Col>
+        <Grid.Col span={1}>
+          <OverviewBlock title="Formal vouchers" loading={loading}>
+            <AttributePillContainer color="white">
+              {data?.species.overview.specimens.formalVouchers}
+            </AttributePillContainer>
+          </OverviewBlock>
+        </Grid.Col>
+        <Grid.Col span={1}>
+          <OverviewBlock title="Tissue available" loading={loading}>
+            <AttributePillContainer color="white">{data?.species.overview.specimens.tissues}</AttributePillContainer>
+          </OverviewBlock>
+        </Grid.Col>
+        <Grid.Col span={1}>
+          <OverviewBlock title="Genomic DNA available" loading={loading}>
+            <AttributePillContainer color="white">{data?.species.overview.specimens.genomicDna}</AttributePillContainer>
+          </OverviewBlock>
+        </Grid.Col>
+        <Grid.Col span={1}>
+          <OverviewBlock title="Australian material" loading={loading}>
+            <AttributePillContainer color="white">
+              {data?.species.overview.specimens.australianMaterial}
+            </AttributePillContainer>
+          </OverviewBlock>
+        </Grid.Col>
+        <Grid.Col span={1}>
+          <OverviewBlock title="Non-Australian material" loading={loading}>
+            <AttributePillContainer color="white">
+              {data?.species.overview.specimens.nonAustralianMaterial}
+            </AttributePillContainer>
+          </OverviewBlock>
+        </Grid.Col>
+      </Grid>
+    </Paper>
+  );
+}
+
+function Explorer({ name }: { name: string }) {
+  const { loading, error, data } = useQuery<MappingQuery>(GET_SPECIMEN_MAP_MARKERS, {
+    variables: { canonicalName: name },
+  });
+
+  const markers = data?.species.mapping.specimens.map((marker) => ({
+    recordId: marker.collectionRepositoryId,
+    latitude: marker.latitude,
+    longitude: marker.longitude,
+    color: [123, 161, 63, 220],
+  }));
+
+  return (
+    <Paper>
+      <Title order={3}>Interactive specimen explorer</Title>
+      <Grid>
+        <Grid.Col span={7}>
+          <Paper pos="relative" radius="xl" style={{ overflow: "hidden" }} h="100%">
+            <AnalysisMap markers={markers} />
+          </Paper>
+        </Grid.Col>
+        <Grid.Col span={5}>
+          <Stack>
+            <HolotypeCard />
+            <SpecimenCard />
+          </Stack>
+        </Grid.Col>
+      </Grid>
+    </Paper>
+  );
+}
+
+function HolotypeCard() {
+  const { details } = { ...useSpecies() };
+
+  const overviewResult = useQuery<OverviewQuery>(GET_SPECIMENS_OVERVIEW, {
+    skip: !details,
+    variables: { canonicalName: details?.name },
+  });
+
+  const { loading, error, data } = useQuery<SpecimenCardQuery>(GET_SPECIMEN_CARD, {
+    skip: !overviewResult.data,
+    variables: { recordId: overviewResult.data?.species.overview.specimens.holotype },
+  });
+
+  const collection = data?.specimen.collections[0];
+  const accession = data?.specimen.accessions[0];
+
+  return (
+    <Paper radius="xl" p={20} bg="bushfire.0">
+      <Title order={4}>Holotype</Title>
+
+      <Group wrap="nowrap">
+        <Table variant="vertical" withRowBorders={false} className={classes.cardTable}>
+          <Table.Tbody>
+            <Table.Tr>
+              <Table.Th>Catalogue number</Table.Th>
+              <Table.Td>
+                {accession?.institutionCode} {accession?.collectionRepositoryId}
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr>
+              <Table.Th>Institution</Table.Th>
+              <Table.Td>{accession?.institutionName ?? accession?.institutionCode}</Table.Td>
+            </Table.Tr>
+            <Table.Tr>
+              <Table.Th>Collection</Table.Th>
+              <Table.Td>{accession?.collectionRepositoryCode}</Table.Td>
+            </Table.Tr>
+            <Table.Tr>
+              <Table.Th>Type location</Table.Th>
+              <Table.Td>{collection?.locality}</Table.Td>
+            </Table.Tr>
+            <Table.Tr>
+              <Table.Th>Coordinates</Table.Th>
+              <Table.Td>
+                {collection?.latitude}, {collection?.longitude}
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr>
+              <Table.Th>Collected by</Table.Th>
+              <Table.Td>{collection?.collectedBy}</Table.Td>
+            </Table.Tr>
+            <Tooltip
+              label="person or persons providing identification as denoted in the registration of the specimen into a formalised institution or other informal collection"
+              w={400}
+              position="bottom"
+              color="shellfish"
+              transitionProps={{ transition: "pop", duration: 300 }}
+              multiline
+              withArrow
+            >
+              <Table.Tr>
+                <Table.Th>Identified by</Table.Th>
+                <Table.Td>{accession?.identifiedBy}</Table.Td>
+              </Table.Tr>
+            </Tooltip>
+          </Table.Tbody>
+        </Table>
+
+        <Stack>
+          <Image w={200} h={200} src="/icons/specimen-listing/Specimen listing_ accession.svg" alt="Holotype badge" />
+          <Button bg="midnight.9" radius="xl">
+            record history
+          </Button>
+        </Stack>
+      </Group>
+    </Paper>
+  );
+}
+
+function SpecimenCard() {
+  return (
+    <Paper radius="xl" p={20} withBorder>
+      <Title order={4}>Specimen</Title>
+
+      <Table variant="vertical" withRowBorders={false} className={classes.cardTable}>
+        <Table.Tbody>
+          <Table.Tr>
+            <Table.Th>Registration number</Table.Th>
+            <Table.Td></Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>Institution</Table.Th>
+            <Table.Td></Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>Specimen status</Table.Th>
+            <Table.Td></Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>Preparation type</Table.Th>
+            <Table.Td></Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>Collection location</Table.Th>
+            <Table.Td></Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>Coordinates</Table.Th>
+            <Table.Td></Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>Collected by</Table.Th>
+            <Table.Td></Table.Td>
+          </Table.Tr>
+          <Table.Tr>
+            <Table.Th>Identified by</Table.Th>
+            <Table.Td></Table.Td>
+          </Table.Tr>
+        </Table.Tbody>
+      </Table>
+    </Paper>
+  );
+}
+
+function AllSpecimens() {
+  return (
+    <Paper radius="lg" p={20} bg="shellfishBg.0">
+      <Title order={3} c="shellfish">
+        All specimens
+      </Title>
+    </Paper>
+  );
+}
+
+export default function Page() {
+  const { details } = { ...useSpecies() };
+  if (!details) return;
+
+  return (
+    <Stack gap="xl">
+      <Overview name={details.name} />
+      <Explorer name={details.name} />
+      <AllSpecimens />
+    </Stack>
+  );
+}
+
+interface CollectionYearsGraphProps {
+  data: YearValue<number>[];
+}
+
+function CollectionYearsGraph({ data }: CollectionYearsGraphProps) {
+  return (
+    <ParentSize>
+      {(parent) => {
+        const xScale = scaleBand({
+          range: [0, parent.width],
+          domain: data.map((stat) => stat.year),
+          padding: 0.4,
+        });
+
+        const yScale = scaleLinear({
+          range: [0, parent.height - 20],
+          domain: [0, max(data, (d) => d.value) ?? 0],
+        });
+
+        return (
+          <SimpleBarGraph
+            width={parent.width}
+            height={parent.height}
+            xScale={xScale}
+            yScale={yScale}
+            data={data}
+            getX={(d: YearValue<number>) => d.year}
+            getY={(d: YearValue<number>) => d.value}
+            tickValues={[min(xScale.domain()) ?? 0, max(xScale.domain()) ?? 0]}
+          />
+        );
+      }}
+    </ParentSize>
+  );
 }

--- a/src/components/graphing/SimpleBarGraph.module.css
+++ b/src/components/graphing/SimpleBarGraph.module.css
@@ -1,0 +1,9 @@
+.simpleBar {
+    fill: var(--mantine-color-shellfish-5);
+    opacity: 0.6;
+}
+
+.axisLine {
+    stroke: var(--mantine-color-midnight-5);
+    stroke-width: 2px;
+}

--- a/src/components/graphing/SimpleBarGraph.tsx
+++ b/src/components/graphing/SimpleBarGraph.tsx
@@ -1,0 +1,59 @@
+import classes from "./SimpleBarGraph.module.css";
+
+import { Group } from "@visx/group";
+import { ScaleBand } from "d3";
+import { AxisBottom } from "@visx/axis";
+import { Line } from "@visx/shape";
+
+interface SimpleBarGraphProps<TypeX extends { toString(): string }, TypeY, Datum> {
+  width: number;
+  height: number;
+  xScale: ScaleBand<TypeX>;
+  yScale: (y: TypeY) => number | undefined;
+  data: Datum[];
+
+  getX: (datum: Datum) => TypeX;
+  getY: (datum: Datum) => TypeY;
+  tickValues?: TypeX[];
+}
+
+export default function SimpleBarGraph<TypeX extends { toString(): string }, TypeY, Datum>({
+  width,
+  height,
+  data,
+  xScale,
+  yScale,
+  getX,
+  getY,
+  tickValues,
+}: SimpleBarGraphProps<TypeX, TypeY, Datum>) {
+  return (
+    <svg width={width} height={height}>
+      {data.map((datum) => {
+        const x = xScale(getX(datum));
+        const y = yScale(getY(datum)) ?? 0;
+
+        return (
+          <Group left={x} key={getX(datum).toString()}>
+            <Group top={height - y - 21}>
+              <rect className={classes.simpleBar} width={xScale.bandwidth()} height={y}></rect>
+            </Group>
+          </Group>
+        );
+      })}
+
+      <Line from={{ x: 1, y: 0 }} to={{ x: 1, y: height - 19 }} className={classes.axisLine} />
+      <Group top={height - 20}>
+        <AxisBottom
+          scale={xScale}
+          hideTicks={true}
+          tickLength={0}
+          labelOffset={2}
+          tickValues={tickValues}
+          axisLineClassName={classes.axisLine}
+          labelClassName={classes.axisLine}
+        />
+      </Group>
+    </svg>
+  );
+}

--- a/src/queries/client.tsx
+++ b/src/queries/client.tsx
@@ -1,7 +1,7 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 import { createFragmentRegistry } from "@apollo/client/cache";
 
-import { ACCESSION_EVENT, COLLECTION_EVENT, SPECIMEN } from "./specimen";
+import { ACCESSION_EVENT, COLLECTION_EVENT, SPECIMEN, SPECIMEN_OVERVIEW, SPECIMEN_MAP_MARKER } from "./specimen";
 import { SUBSAMPLE, SUBSAMPLE_EVENT } from "./subsample";
 import { DNA_EXTRACT, DNA_EXTRACTION_EVENT } from "./dna-extract";
 import { TAXON_TREE_NODE_STATISTICS } from "./stats";
@@ -19,6 +19,8 @@ import { PUBLICATION } from "./publication";
 export default function createClient() {
   const fragments = createFragmentRegistry(
     SPECIMEN,
+    SPECIMEN_OVERVIEW,
+    SPECIMEN_MAP_MARKER,
     SUBSAMPLE,
     DNA_EXTRACT,
     SEQUENCE,
@@ -35,7 +37,7 @@ export default function createClient() {
     TAXON_NAME,
     TAXON_SOURCE,
     TAXON_NODE,
-    PUBLICATION
+    PUBLICATION,
   );
 
   // for now just use the memory cache to help reduce the total amount of server requests.

--- a/src/queries/specimen.tsx
+++ b/src/queries/specimen.tsx
@@ -2,161 +2,216 @@ import { gql } from "@apollo/client";
 
 export const SPECIMEN = gql`
   fragment SpecimenDetails on Specimen {
-    recordId
     entityId
     organismId
-    materialSampleId
-    collectionCode
-    institutionName
-    institutionCode
-    recordedBy
-    identifiedBy
-    identifiedDate
-    typeStatus
-    latitude
-    longitude
-    locationSource
-    locality
-    country
-    countryCode
-    county
-    municipality
-    stateProvince
-    depth
-    elevation
-    depthAccuracy
-    elevationAccuracy
-    details
-    remarks
-    identificationRemarks
+    canonicalName
   }
 `;
 
 export interface Specimen {
-  recordId: string;
-  entityId?: string;
-  organismId?: string;
-  materialSampleId?: string;
-  collectionCode?: string;
-  institutionName?: string;
+  entityId: string;
+  organismId: string;
+  canonicalName: string;
+}
+
+export const SPECIMEN_SUMMARY = gql`
+  fragment SpecimenSummary on Specimen {
+    entityId
+    collectionRepositoryId
+    collectionRepositoryCode
+    institutionCode
+    institutionName
+    typeStatus
+    locality
+    country
+    latitude
+    longitude
+    sequences
+    wholeGenomes
+    markers
+  }
+`;
+
+export interface SpecimenSummary {
+  entityId: string;
+  collectionRepositoryId?: string;
+  collectionRepositoryCode?: string;
   institutionCode?: string;
-  recordedBy?: string;
-  identifiedBy?: string;
-  identifiedDate?: string;
+  institutionName?: string;
   typeStatus?: string;
-  latitude?: number;
-  longitude?: number;
-  locationSource?: string;
   locality?: string;
   country?: string;
-  countryCode?: string;
-  county?: string;
-  municipality?: string;
-  stateProvince?: string;
-  depth?: string;
-  elevation?: string;
-  depthAccuracy?: string;
-  elevationAccuracy?: string;
-  details?: string;
-  remarks?: string;
-  identificationRemarks?: string;
-  markers?: number;
+  latitude?: number;
+  longitude?: number;
   sequences?: number;
   wholeGenomes?: number;
+  markers?: number;
+}
+
+export const SPECIMEN_OVERVIEW = gql`
+  fragment SpecimenOverviewDetails on SpecimensOverview {
+    total
+    majorCollections
+    holotype
+    otherTypes
+    formalVouchers
+    tissues
+    genomicDna
+    australianMaterial
+    nonAustralianMaterial
+    collectionYears {
+      year
+      value
+    }
+  }
+`;
+
+export interface SpecimenOverview {
+  total: number;
+  majorCollections: string[];
+  holotype?: string;
+  otherTypes?: number;
+  formalVouchers?: number;
+  tissues?: number;
+  genomicDna?: number;
+  australianMaterial?: number;
+  nonAustralianMaterial?: number;
+  collectionYears: YearValue<number>[];
+}
+
+export interface YearValue<T> {
+  year: number;
+  value: T;
+}
+
+export const SPECIMEN_MAP_MARKER = gql`
+  fragment SpecimenMapMarkerDetails on SpecimenMapMarker {
+    collectionRepositoryId
+    typeStatus
+    latitude
+    longitude
+  }
+`;
+
+export interface SpecimenMapMarker {
+  collectionRepositoryId?: string;
+  typeStatus?: string;
+  latitude: number;
+  longitude: number;
 }
 
 export const COLLECTION_EVENT = gql`
   fragment CollectionEventDetails on CollectionEvent {
+    entityId
+    fieldCollectingId
     eventDate
     eventTime
     collectedBy
-    behavior
-    catalogNumber
-    degreeOfEstablishment
-    envBroadScale
-    envLocalScale
-    envMedium
+    collectionRemarks
+    identifiedBy
+    identifiedDate
+    identificationRemarks
+    locality
+    country
+    countryCode
+    stateProvince
+    county
+    municipality
+    latitude
+    longitude
+    elevation
+    depth
+    elevationAccuracy
+    depthAccuracy
+    locationSource
+    preparation
+    environmentBroadScale
+    environmentLocalScale
+    environmentMedium
     habitat
-    establishmentMeans
+    specificHost
     individualCount
-    isolate
-    lifeStage
-    occurrenceStatus
     organismQuantity
     organismQuantityType
-    otherCatalogNumbers
-    pathway
-    preparation
-    recordNumber
-    refBiomaterial
-    reproductiveCondition
-    sex
-    genotypicSex
-    phenotypicSex
-    sourceMatId
-    specificHost
     strain
-    fieldNumber
+    isolate
     fieldNotes
-    remarks
   }
 `;
 
 export interface CollectionEvent {
-  eventDate?: string;
+  entityId: string;
+  fieldCollectingId?: string;
+  eventDate?: Date;
   eventTime?: string;
   collectedBy?: string;
-  behavior?: string;
-  catalogNumber?: string;
-  degreeOfEstablishment?: string;
-  envBroadScale?: string;
-  envLocalScale?: string;
-  envMedium?: string;
+  collectionRemarks?: string;
+  identifiedBy?: string;
+  identifiedDate?: Date;
+  identificationRemarks?: string;
+  locality?: string;
+  country?: string;
+  countryCode?: string;
+  stateProvince?: string;
+  county?: string;
+  municipality?: string;
+  latitude?: number;
+  longitude?: number;
+  elevation?: number;
+  depth?: number;
+  elevationAccuracy?: number;
+  depthAccuracy?: number;
+  locationSource?: string;
+  preparation?: string;
+  environmentBroadScale?: string;
+  environmentLocalScale?: string;
+  environmentMedium?: string;
   habitat?: string;
-  establishmentMeans?: string;
+  specificHost?: string;
   individualCount?: string;
-  isolate?: string;
-  lifeStage?: string;
-  occurrenceStatus?: string;
   organismQuantity?: string;
   organismQuantityType?: string;
-  otherCatalogNumbers?: string;
-  pathway?: string;
-  preparation?: string;
-  recordNumber?: string;
-  refBiomaterial?: string;
-  reproductiveCondition?: string;
-  sex?: string;
-  genotypicSex?: string;
-  phenotypicSex?: string;
-  sourceMatId?: string;
-  specificHost?: string;
   strain?: string;
-  fieldNumber?: string;
+  isolate?: string;
   fieldNotes?: string;
-  remarks?: string;
 }
 
 export const ACCESSION_EVENT = gql`
   fragment AccessionEventDetails on AccessionEvent {
+    entityId
+    typeStatus
     eventDate
     eventTime
-    accession
-    accessionedBy
+    collectionRepositoryId
+    collectionRepositoryCode
     institutionName
     institutionCode
-    materialSampleId
-    typeStatus
+    disposition
+    preparation
+    accessionedBy
+    preparedBy
+    identifiedBy
+    identifiedDate
+    identificationRemarks
+    otherCatalogNumbers
   }
 `;
 
 export interface AccessionEvent {
-  eventDate?: string;
+  entityId: string;
+  typeStatus?: string;
+  eventDate?: Date;
   eventTime?: string;
-  accession?: string;
-  accessionedBy?: string;
+  collectionRepositoryId?: string;
+  collectionRepositoryCode?: string;
   institutionName?: string;
   institutionCode?: string;
-  materialSampleId?: string;
-  typeStatus?: string;
+  disposition?: string;
+  preparation?: string;
+  accessionedBy?: string;
+  preparedBy?: string;
+  identifiedBy?: string;
+  identifiedDate?: Date;
+  identificationRemarks?: string;
+  otherCatalogNumbers?: string;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -12,6 +12,34 @@ export const gothamBold = localFont({
   src: "../public/fonts/gotham/GothamBold.ttf",
 });
 
+/*** BRAND COLOURS ***
+ *
+ * Midnight
+ *   CMYK 87 67 50 42
+ *   RGB 35 60 75
+ *   HEX #233C4B
+ *
+ * Shellfish
+ *   CMYK 66 17 40 2
+ *   RGB 88 163 157
+ *   HEX #58A39D
+ *
+ * Moss
+ *   CMYK 40 7 73 0
+ *   RGB 162 195 110
+ *   HEX #A2C36E
+ *
+ * Bushfire
+ *   CMYK 0 64 92 0
+ *   RGB 244 124 46
+ *   HEX #F47C2E
+ *
+ * Wheat
+ *   CMYK 0 22 84 0
+ *   RGB 254 199 67
+ *   HEX #FEC743
+ *********************/
+
 export const theme = createTheme({
   colors: {
     // midnight: ['#e7f4ff', '#c8dce9', '#a8c5d6', '#87aec5', '#6797b4', '#486471', '#2d4d5c', '#193d4d', '#15313f', '#001017'],
@@ -101,6 +129,32 @@ export const theme = createTheme({
       "#4e938e",
       "#40847f",
       "#2b736d",
+    ],
+
+    wheatBg: [
+      "rgba(254, 199, 67, 0.1)",
+      "rgba(254, 199, 67, 0.2)",
+      "rgba(254, 199, 67, 0.3)",
+      "rgba(254, 199, 67, 0.4)",
+      "rgba(254, 199, 67, 0.5)",
+      "rgba(254, 199, 67, 0.6)",
+      "rgba(254, 199, 67, 0.7)",
+      "rgba(254, 199, 67, 0.8)",
+      "rgba(254, 199, 67, 0.9)",
+      "rgba(254, 199, 67, 1.0)",
+    ],
+
+    shellfishBg: [
+      "rgba(88, 163, 157, 0.1)",
+      "rgba(88, 163, 157, 0.2)",
+      "rgba(88, 163, 157, 0.3)",
+      "rgba(88, 163, 157, 0.4)",
+      "rgba(88, 163, 157, 0.5)",
+      "rgba(88, 163, 157, 0.6)",
+      "rgba(88, 163, 157, 0.7)",
+      "rgba(88, 163, 157, 0.8)",
+      "rgba(88, 163, 157, 0.9)",
+      "rgba(88, 163, 157, 1.0)",
     ],
   },
 


### PR DESCRIPTION
This PR is the redesign of the species specimens page as well as the individual specimen details page.
It contains:
- an overview of the specimens assigned to the species name
- a more interactive map view
- lots more details
- using the newly refactored specimen APIs