### PR TITLE
Enable group browsing

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -2,7 +2,7 @@
 
 import { gql, useQuery } from "@apollo/client";
 import { Box, Center, Flex, Group, Stack, Text, Title } from "@mantine/core";
-import { IconSearch } from "@tabler/icons-react";
+import { IconArrowUpRight, IconSearch } from "@tabler/icons-react";
 import { useMemo } from "react";
 import { ShowStats, TaxonomicComposition } from "./stats";
 
@@ -15,6 +15,7 @@ import Browse from "./browse";
 import classes from "./page.module.css";
 
 // Browse data
+import { InternalLinkButton } from "@/components/button-link-internal";
 import { Search } from "@/components/search";
 import { Overview } from "@/generated/types";
 import { grouping, taxon, type } from "./_data";
@@ -128,8 +129,8 @@ export default function HomePage() {
               <Title order={3} c="moss.5" fz={28}>
                 Browse by functional or ecological group
               </Title>
-              <Browse items={grouping} data={formattedData} error={error} disabled />
-              {/* <InternalLinkButton
+              <Browse items={grouping} data={formattedData} error={error} />
+              <InternalLinkButton
                 url={`/browse/groups`}
                 icon={IconArrowUpRight}
                 textColor="white"
@@ -137,7 +138,7 @@ export default function HomePage() {
                 outline
               >
                 View all groups
-              </InternalLinkButton> */}
+              </InternalLinkButton>
             </Stack>
           </Stack>
           <Group gap={140} pb={80} align="flex-start" justify="center">


### PR DESCRIPTION
Uncomments the InternalLinkButton for viewing all groups and enables the Browse component on the home page.