### PR TITLE
List group & home page tweaks

### DIFF
--- a/src/app/(home)/_data/grouping.ts
+++ b/src/app/(home)/_data/grouping.ts
@@ -2,43 +2,36 @@ import { BrowseItem } from "../browse";
 
 export const grouping: BrowseItem[] = [
   {
-    // total: "sources.ARGA Commercial Species",
     category: "Agriculture",
     image: "/icons/list-group/List group_ Agriculture.svg",
     link: "/browse/list-groups/Agriculture",
   },
   {
-    // total: "sources.ARGA Commercial Species",
     category: "Aquaculture",
     image: "/icons/list-group/List group_ Aquaculture.svg",
     link: "/browse/list-groups/Aquaculture",
   },
   {
-    // total: "sources.ARGA Commercial Species",
     category: "Crop Wild Relatives",
     image: "/icons/list-group/List group_ crop wild relative.svg",
     link: "/browse/list-groups/Crop Wild Relatives",
   },
   {
-    // total: "sources.ARGA Commercial Species",
     category: "Medicinal and Bioactive",
     image: "/icons/list-group/List group_ medicinal and bioactive.svg",
     link: "/browse/list-groups/Medicinal and Bioactive",
   },
   {
-    // total: "sources.ARGA Venomous and Poisonous Species",
     category: "Venomous and Poisonous",
     image: "/icons/list-group/List group_ Venomous and poisonous.svg",
     link: "/browse/sources/ARGA Venomous and Poisonous Species",
   },
   {
-    // total: "sources.ARGA Threatened Species",
     category: "Threatened",
     image: "/icons/list-group/List group_ Threatened species.svg",
     link: "/browse/sources/ARGA Threatened Species",
   },
   {
-    // total: "sources.ARGA Bushfire Recovery",
     category: "Bushfire Vulnerable",
     image: "/icons/list-group/List group_ Bushfire vulnerable.svg",
     link: "/browse/sources/ARGA Bushfire Recovery",


### PR DESCRIPTION
This PR represents a review of `app/browse/list-groups`, the home page, and the following key commits pushed to `main` (smaller superficial changes omitted for brevity):
- 1dc8b79ffe0af643a91e2d58399915e0cef99a62
  - Replaces VERNACULAR_GROUP_ICON with TAXON_ICONS throughout the codebase, consolidates and expands icon definitions, and updates helper logic to use rank and canonical name for icon lookup. Removes unused grouping logic, fixes several icon links, and adds missing taxon group types.
- 84cd65a5020e2f55acd6051e87d7ff36afca2f73
  - Renamed /browse/groups to /browse/list-groups for clarity
- 8ec44c5f1ff108def9dfb8e1711da18c14835a47
  - Improves taxonomy rank normalization and Latin/normal rank handling across taxonomy pages and components. Updates dataset and source page UI styles for better clarity and consistency, including new contained image component and enhanced dataset/source cards.
- 6cec0351ed69d18cd3eb34201f8ed6306790f6c0
  - Updated group and browse card components to add image hover scaling and improved layout. Refactored species image attribution to use a new ContainedImage component, removing CSS-based attribution styling.
- 86929809f96681fc9fc9e57f1f8264c66f84d368
  - Moved and renamed list group card components and styles to a new `_components` directory for better organization. Added 'List group_ Australian iconic species.svg' icon. Updated data and page files to reflect new structure and improved styling.
- 61377a662813a1d7e8e3992c1519de039b3e3ed5
  - Filtering logic uplift, adding various new filters